### PR TITLE
Update MQTT defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ The system consists of a microphone array connected to an ESP32.
 `sim_module.py` emulates the ESP32 output while hardware is unavailable. The script
 creates weak sinusoidal signals, adds synthetic white and pink noise according
 to a chosen SNR, quantizes the result to `float32` and publishes packets over
-MQTT using a MessagePack payload. The default topic is `USTYM/LPNU`.
+MQTT using a MessagePack payload. The default broker is the public HiveMQ instance
+`broker.mqttdashboard.com` and the default topic is `USTYM/LPNU`.
 
 A real‑time mode can be enabled with `--realtime` which transmits data at twice
 the normal sampling rate for faster algorithm testing.
@@ -31,13 +32,13 @@ the normal sampling rate for faster algorithm testing.
 
 - **Signal simulator**:
   ```bash
-  python sim_module.py --host <mqtt-host> --port 1883 --topic USTYM/LPNU
+  python sim_module.py --host broker.mqttdashboard.com --port 1883 --topic USTYM/LPNU
   ```
   Add `--realtime` to double the output speed.
 
 - **Calibration suite**:
   ```bash
-  python calibration_suite.py --host <mqtt-host> --port 1883 --topic USTYM/CALIB
+  python calibration_suite.py --host broker.mqttdashboard.com --port 1883 --topic USTYM/CALIB
   ```
 
 - **Web interface**:

--- a/calibration_suite.py
+++ b/calibration_suite.py
@@ -31,7 +31,11 @@ def generate_signals(room_dim, mic_positions, source_pos, amplitudes, fs, tone_f
 
 def main():
     parser = argparse.ArgumentParser(description="Calibration signal generator")
-    parser.add_argument("--host", default="localhost", help="MQTT broker host")
+    parser.add_argument(
+        "--host",
+        default="broker.mqttdashboard.com",
+        help="MQTT broker host",
+    )
     parser.add_argument("--port", type=int, default=1883, help="MQTT broker port")
     parser.add_argument("--topic", default="USTYM/CALIB", help="MQTT topic")
     parser.add_argument("--rate", type=int, default=16000, help="Sampling rate")

--- a/sim_module.py
+++ b/sim_module.py
@@ -36,7 +36,11 @@ def generate_packet(size, snr_db, sample_rate):
 
 def main():
     parser = argparse.ArgumentParser(description="ESP32 signal simulator")
-    parser.add_argument("--host", default="localhost", help="MQTT broker host")
+    parser.add_argument(
+        "--host",
+        default="broker.mqttdashboard.com",
+        help="MQTT broker host",
+    )
     parser.add_argument("--port", type=int, default=1883, help="MQTT broker port")
     parser.add_argument("--topic", default="USTYM/LPNU", help="MQTT topic")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default to the public HiveMQ broker at `broker.mqttdashboard.com`
- document how to run using the HiveMQ broker

## Testing
- `python -m py_compile sim_module.py calibration_suite.py data_storage.py web_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_68405f3336e48327a3701ed549f2f85e