### PR TITLE
Connect simulator to web dashboard via MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,27 @@ MQTT using a MessagePack payload. The default broker is the public HiveMQ instan
 A real‑time mode can be enabled with `--realtime` which transmits data at twice
 the normal sampling rate for faster algorithm testing.
 
+`sim_realtime.py` publishes JSON frames with random coordinates, intensity and a
+simple spectrum at a configurable frame rate. The first message also contains the
+microphone geometry so that the browser can display it. Geometry can be requested
+again by sending `get_mics` to the `<topic>/cmd` MQTT topic.
+
 ## Calibration Suite
-`calibration_suite.py` generates multichannel test signals using synthetic room impulse responses produced by [Pyroomacoustics](https://github.com/LCAV/pyroomacoustics). The script sends packets to an MQTT broker with the true source coordinates and varying tone amplitudes. This data can be collected by `HostCollector` to evaluate localization accuracy and tune classification thresholds.
- 
+`calibration_suite.py` generates multichannel test signals using synthetic room
+impulse responses produced by [Pyroomacoustics](https://github.com/LCAV/pyroomacoustics).
+The script sends packets to an MQTT broker with the true source coordinates and
+varying tone amplitudes. This data can be collected by `HostCollector` to evaluate
+localization accuracy and tune classification thresholds.
+
 ## Web Interface
-`web_interface.py` launches a small Flask application that streams randomized coordinates over SocketIO. These values are visualized in the browser as a heatmap and a detection timeline using Plotly. The dashboard page includes simple styling for a cleaner layout.
+`web_interface.py` launches a Flask application that subscribes to the simulator
+MQTT topic and forwards JSON frames to the browser via SocketIO. The dashboard
+plots microphone positions, the detected source and its spectrum in real time using Plotly.
 
 ## Data Storage
-`data_storage.py` implements asynchronous writes to a SQLite database. Event samples and filter parameters are kept in separate tables indexed by timestamp for quick statistical queries.
+`data_storage.py` implements asynchronous writes to a SQLite database. Event samples
+and filter parameters are kept in separate tables indexed by timestamp for quick
+statistical queries.
 
 ## Setup
 
@@ -35,6 +48,11 @@ the normal sampling rate for faster algorithm testing.
   python sim_module.py --host broker.mqttdashboard.com --port 1883 --topic USTYM/LPNU
   ```
   Add `--realtime` to double the output speed.
+
+- **Real-time JSON simulator**:
+  ```bash
+  python sim_realtime.py --host broker.mqttdashboard.com --port 1883 --topic USTYM/LPNU
+  ```
 
 - **Calibration suite**:
   ```bash

--- a/sim_realtime.py
+++ b/sim_realtime.py
@@ -1,0 +1,80 @@
+import argparse
+import asyncio
+import json
+import random
+import time
+from typing import List
+
+import numpy as np
+import paho.mqtt.client as mqtt
+
+
+async def publish_loop(host: str, port: int, topic: str, fps: float, mics: List[List[float]]):
+    """Publish random coordinates with spectrum at the given rate."""
+    client = mqtt.Client()
+    connected = asyncio.Event()
+
+    def on_connect(client, userdata, flags, rc):  # noqa: D401
+        if rc == 0:
+            connected.set()
+            client.subscribe(topic + "/cmd")
+
+    def on_disconnect(client, userdata, rc):  # noqa: D401
+        connected.clear()
+
+    def on_message(client, userdata, msg):  # noqa: D401
+        if msg.topic.endswith("/cmd") and msg.payload.decode() == "get_mics":
+            payload = json.dumps({"mics": mics})
+            client.publish(topic, payload)
+
+    client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
+    client.on_message = on_message
+    client.reconnect_delay_set(min_delay=1, max_delay=5)
+    client.connect_async(host, port)
+    client.loop_start()
+    await connected.wait()
+
+    interval = 1.0 / fps
+    send_mics = True
+    try:
+        while True:
+            ts = time.time()
+            x = random.uniform(0, 10)
+            y = random.uniform(0, 10)
+            intensity = random.random()
+            spectrum = (
+                np.abs(np.fft.rfft(np.random.randn(128))) / 64
+            ).tolist()
+
+            payload = {
+                "timestamp": ts,
+                "coords": [x, y],
+                "intensity": intensity,
+                "spectrum": spectrum,
+            }
+            if send_mics:
+                payload["mics"] = mics
+                send_mics = False
+            client.publish(topic, json.dumps(payload))
+            await asyncio.sleep(interval)
+    finally:
+        client.loop_stop()
+        client.disconnect()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Real-time JSON simulator")
+    parser.add_argument("--host", default="broker.mqttdashboard.com")
+    parser.add_argument("--port", type=int, default=1883)
+    parser.add_argument("--topic", default="USTYM/LPNU")
+    parser.add_argument("--fps", type=float, default=15.0, help="Frames per second")
+    args = parser.parse_args()
+
+    mics = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
+
+    asyncio.run(publish_loop(args.host, args.port, args.topic, args.fps, mics))
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <title>Detection Dashboard</title>
+    <title>Sound Source Viewer</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -22,32 +22,41 @@
     </style>
 </head>
 <body>
-<h1>Detection Dashboard</h1>
+<h1>Sound Source Viewer</h1>
 <div class="charts">
-    <div id="heatmap" style="width:600px;height:400px;"></div>
-    <div id="timeline" style="width:600px;height:400px;"></div>
+    <div id="area" style="width:600px;height:400px;"></div>
+    <div id="spectrum" style="width:600px;height:400px;"></div>
 </div>
 <script>
 const socket = io();
-
-const gridSize = 10;
-let z = Array.from({length: gridSize}, () => Array(gridSize).fill(0));
-let heatmap = {z: z, type: 'heatmap'};
-Plotly.newPlot('heatmap', [heatmap]);
-
-let timeData = {x: [], y: [], mode: 'lines', type: 'scatter'};
-Plotly.newPlot('timeline', [timeData]);
+let micTrace = {x: [], y: [], mode: 'markers', marker: {color: 'blue', size: 8}, name: 'mics'};
+let sourceTrace = {x: [0], y: [0], mode: 'markers', marker: {color: 'red', size: 10}, name: 'source'};
+Plotly.newPlot('area', [micTrace, sourceTrace], {xaxis: {range:[0,10]}, yaxis:{range:[0,10]}, margin:{t:20}});
+let specTrace = {x: [], y: [], mode: 'lines', name: 'spectrum'};
+Plotly.newPlot('spectrum', [specTrace], {margin:{t:20}});
 
 socket.on('coords', function(data) {
-    const {x, y, intensity} = data;
-    if (x < gridSize && y < gridSize) {
-        z[y][x] += intensity;
-        Plotly.update('heatmap', {z: [z]});
+    if (data.mics) {
+        micTrace.x = data.mics.map(p => p[0]);
+        micTrace.y = data.mics.map(p => p[1]);
     }
-    const now = new Date();
-    timeData.x.push(now);
-    timeData.y.push(intensity);
-    Plotly.update('timeline', {x: [timeData.x], y: [timeData.y]});
+    if (data.coords) {
+        sourceTrace.x = [data.coords[0]];
+        sourceTrace.y = [data.coords[1]];
+    }
+    if (data.intensity !== undefined) {
+        sourceTrace.marker.size = Math.max(5, data.intensity * 30);
+    }
+    Plotly.update('area', {
+        x: [micTrace.x, sourceTrace.x],
+        y: [micTrace.y, sourceTrace.y],
+        'marker.size': [micTrace.marker.size, sourceTrace.marker.size]
+    });
+    if (data.spectrum) {
+        specTrace.x = data.spectrum.map((_, i) => i);
+        specTrace.y = data.spectrum;
+        Plotly.update('spectrum', {x:[specTrace.x], y:[specTrace.y]});
+    }
 });
 </script>
 </body>

--- a/web_interface.py
+++ b/web_interface.py
@@ -1,8 +1,10 @@
-import random
+import argparse
+import json
 import time
 import eventlet
 from flask import Flask, render_template
-from flask_socketio import SocketIO, emit
+from flask_socketio import SocketIO
+import paho.mqtt.client as mqtt
 
 from data_storage import DataStorage
 
@@ -13,32 +15,54 @@ socketio = SocketIO(app, cors_allowed_origins='*', async_mode='eventlet')
 
 storage = DataStorage()
 
+
+def create_mqtt_client(host: str, port: int, topic: str) -> mqtt.Client:
+    client = mqtt.Client()
+
+    def on_connect(client, userdata, flags, rc):  # noqa: D401
+        if rc == 0:
+            client.subscribe(topic)
+            client.subscribe(topic + "/cmd")
+
+    def on_message(client, userdata, msg):  # noqa: D401
+        if msg.topic.endswith("/cmd"):
+            if msg.payload.decode() == "get_mics":
+                client.publish(topic + "/cmd", "ack")
+            return
+        data = json.loads(msg.payload.decode())
+        coords = data.get("coords", [0, 0])
+        storage.insert_event(time.time(), coords[0], coords[1], data.get("intensity", 0))
+        socketio.emit("coords", data)
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.reconnect_delay_set(min_delay=1, max_delay=5)
+    client.connect_async(host, port)
+    client.loop_start()
+    return client
+
+
 @app.get('/')
 def index():
     return render_template('index.html')
 
 
-@socketio.on('connect')
-def handle_connect():
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Web dashboard")
+    parser.add_argument("--host", default="broker.mqttdashboard.com")
+    parser.add_argument("--port", type=int, default=1883)
+    parser.add_argument("--topic", default="USTYM/LPNU")
+    parser.add_argument("--listen", default="0.0.0.0")
+    parser.add_argument("--web-port", type=int, default=5000)
+    args = parser.parse_args()
 
-    def send_coords():
-        while True:
-            socketio.sleep(1)
-            data = {
-                'x': random.randint(0, 9),
-                'y': random.randint(0, 9),
-                'intensity': random.random(),
-            }
-            storage.insert_event(time.time(), data['x'], data['y'], data['intensity'])
-            emit('coords', data)
+    mqtt_client = create_mqtt_client(args.host, args.port, args.topic)
 
-    eventlet.spawn(send_coords)
-
-
-def main():
     try:
-        socketio.run(app, host='0.0.0.0', port=5000)
+        socketio.run(app, host=args.listen, port=args.web_port)
     finally:
+        mqtt_client.loop_stop()
+        mqtt_client.disconnect()
         storage.close()
 
 


### PR DESCRIPTION
## Summary
- add an asynchronous MQTT simulator `sim_realtime.py`
- update `web_interface.py` to subscribe to MQTT and forward frames over SocketIO
- redesign dashboard to show microphones, sound source and spectrum
- document new real-time workflow in `README.md`

## Testing
- `python -m py_compile sim_realtime.py web_interface.py data_storage.py calibration_suite.py sim_module.py`

------
https://chatgpt.com/codex/tasks/task_e_6840651adaf48327899c14032762dece