### PR TITLE
Add amplitude sequence events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ produces multi-channel measurements containing short impulses on top of pink and
 white noise, determines the inter-channel delays, estimates the source position
 and energy intensity, forms a spectral vector and sends all fields packed with
 MessagePack. Each packet also carries the microphone geometry so the dashboard
-can display the array without additional commands.
+can display the array without additional commands. The simulator can now emit a
+sequence of events with configurable amplitudes so the web dashboard can show
+how detection behaves for several weak signals in a row.
 
 ## Calibration Suite
 `calibration_suite.py` generates multichannel test signals using synthetic room
@@ -39,7 +41,8 @@ statistical queries.
 
 - **Signal simulator**:
   ```bash
-  python sim_full.py --host broker.mqttdashboard.com --port 1883 --topic USTYM/LPNU
+  python sim_full.py --host broker.mqttdashboard.com --port 1883 \
+      --topic USTYM/LPNU --events 5
   ```
 
 - **Calibration suite**:

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,10 +36,11 @@ let pathTrace = {x: [], y: [], mode: 'markers+lines', line:{color:'rgba(255,0,0,
 Plotly.newPlot('area', [micTrace, pathTrace, sourceTrace], {xaxis: {range:[0,10]}, yaxis:{range:[0,10]}, margin:{t:20}});
 let specTrace = {x: [], y: [], mode: 'lines', name: 'spectrum'};
 let intensityTrace = {x: [], y: [], mode: 'lines', name: 'intensity'};
+let amplitudeTrace = {x: [], y: [], mode: 'lines', name: 'amplitude'};
 let history = [];
 const maxPoints = 50;
 Plotly.newPlot('spectrum', [specTrace], {margin:{t:20}});
-Plotly.newPlot('intensity', [intensityTrace], {margin:{t:20}, xaxis:{type:'date'}});
+Plotly.newPlot('intensity', [intensityTrace, amplitudeTrace], {margin:{t:20}, xaxis:{type:'date'}});
 
 socket.on('coords', function(data) {
     if (data.mics) {
@@ -60,11 +61,18 @@ socket.on('coords', function(data) {
         const ts = new Date();
         intensityTrace.x.push(ts);
         intensityTrace.y.push(data.intensity);
+        amplitudeTrace.x.push(ts);
+        amplitudeTrace.y.push(data.amp !== undefined ? data.amp : 0);
         if (intensityTrace.x.length > maxPoints) {
             intensityTrace.x.shift();
             intensityTrace.y.shift();
+            amplitudeTrace.x.shift();
+            amplitudeTrace.y.shift();
         }
-        Plotly.update('intensity', {x:[intensityTrace.x], y:[intensityTrace.y]});
+        Plotly.update('intensity', {
+            x:[intensityTrace.x, amplitudeTrace.x],
+            y:[intensityTrace.y, amplitudeTrace.y]
+        });
     }
     Plotly.update('area', {
         x: [micTrace.x, pathTrace.x, sourceTrace.x],


### PR DESCRIPTION
## Summary
- allow `generate_event` to take a fixed amplitude
- publish a sequence of events with increasing amplitude
- expose amplitude in MQTT payload
- plot amplitude alongside intensity in the dashboard
- document new `--events` option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409782924c83278b2652734dab6d99