### PR TITLE
Add MCU simulator and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# ESP32LocalMicroLowSinalIn2D
+
+This project contains Arduino and Python code for acquiring audio data from four microphones and locating a sound source using Time Difference of Arrival (TDOA).
+
+## Microcontroller simulation
+
+If you do not have the Arduino board connected, you can emulate its serial output using the script `python_codes/mcu_simulator.py`.
+
+1. Run the simulator:
+
+   ```bash
+   python3 python_codes/mcu_simulator.py
+   ```
+
+   The script prints the path of a virtual serial device (for example `/dev/pts/3`).
+   Leave the simulator running.
+
+2. In a separate terminal, start the acquisition script using that port:
+
+   ```bash
+   python3 python_codes/arduino_data_acquisiton_main.py /dev/pts/3
+   ```
+
+   Replace `/dev/pts/3` with the path displayed by the simulator.
+
+Stop the simulator with `Ctrl+C` when you are done.

--- a/python_codes/arduino_data_acquisiton_main.py
+++ b/python_codes/arduino_data_acquisiton_main.py
@@ -7,6 +7,7 @@ from tdoa import tdoa
 from data_visualization import draw_fig_real_time, plot_3d_coordinates
 import numpy as np
 import matplotlib.pyplot as plt
+import sys
 
 if __name__ == "__main__":
     data = []
@@ -14,8 +15,9 @@ if __name__ == "__main__":
     x=[0,0.17,0.17,0.72]
     y=[0,0,0.85,0.61]
     z=[0,0,0,0.13]
-    print("start")
-    ser = serial.Serial('COM6', baudrate=115200)
+    port = sys.argv[1] if len(sys.argv) > 1 else 'COM6'
+    print(f"start (using port {port})")
+    ser = serial.Serial(port, baudrate=115200)
     dateTimeObj=datetime.now()
     start = timeit.default_timer()
     # Read data until you find a signal amplitude value greater than 1.75 V

--- a/python_codes/mcu_simulator.py
+++ b/python_codes/mcu_simulator.py
@@ -1,0 +1,27 @@
+import os
+import pty
+import random
+import time
+import sys
+
+
+def main():
+    master, slave = pty.openpty()
+    slave_name = os.ttyname(slave)
+    print(f"Simulated serial port: {slave_name}")
+    sys.stdout.flush()
+
+    try:
+        while True:
+            # Generate four random voltage readings between 0 and 3.3V
+            readings = [random.uniform(0, 3.3) for _ in range(4)]
+            for value in readings:
+                line = f"{value:.2f}\r\n".encode()
+                os.write(master, line)
+                time.sleep(0.01)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `mcu_simulator.py` to emulate the Arduino serial output
- let `arduino_data_acquisiton_main.py` accept a serial port parameter
- document how to use the new simulator in `README.md`

## Testing
- `python3 -m py_compile python_codes/*.py`
- `python3 -m py_compile python_codes/mcu_simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_684421da8d58832794e55141c66e0cf1