### PR TITLE
Add deterministic serial data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,22 @@ This project contains Arduino and Python code for acquiring audio data from four
 
 ## Microcontroller simulation
 
-If you do not have the Arduino board connected, you can emulate its serial output using the script `python_codes/mcu_simulator.py`.
+If you do not have the Arduino board connected, you can emulate its serial output using the script `python_codes/mcu_simulator.py`.  The simulator
+produces four microphone signals with appropriate inter-channel delays and
+sends them over a virtual serial port (by default `COM11`).
 
-1. Run the simulator:
+1. Run the simulator (change the port if necessary):
 
    ```bash
-   python3 python_codes/mcu_simulator.py
+   python3 python_codes/mcu_simulator.py COM11
    ```
 
-   The script prints the path of a virtual serial device (for example `/dev/pts/3`).
    Leave the simulator running.
 
-2. In a separate terminal, start the acquisition script using that port:
+2. In a separate terminal, start the acquisition script using the same port:
 
    ```bash
-   python3 python_codes/arduino_data_acquisiton_main.py /dev/pts/3
+   python3 python_codes/arduino_data_acquisiton_main.py COM11
    ```
-
-   Replace `/dev/pts/3` with the path displayed by the simulator.
 
 Stop the simulator with `Ctrl+C` when you are done.

--- a/python_codes/mcu_simulator.py
+++ b/python_codes/mcu_simulator.py
@@ -1,26 +1,57 @@
-import os
-import pty
-import random
+"""Simulated microcontroller sending deterministic data over a serial port."""
+
 import time
 import sys
+from typing import Sequence
+
+import numpy as np
+import serial
 
 
 def main():
-    master, slave = pty.openpty()
-    slave_name = os.ttyname(slave)
-    print(f"Simulated serial port: {slave_name}")
+    """Send pre-generated signals with delays to the specified serial port."""
+
+    port = sys.argv[1] if len(sys.argv) > 1 else "COM11"
+    baud = 115200
+
+    def generate_signals(
+        fs: int = 1000,
+        duration: float = 2.0,
+        freq: float = 40.0,
+        delays: Sequence[float] = (0.0, 0.0005, 0.001, 0.0015),
+    ) -> np.ndarray:
+        """Create a set of sine waves with different delays."""
+
+        t = np.arange(0.0, duration, 1.0 / fs)
+        base = np.sin(2 * np.pi * freq * t)
+        signals = []
+        for d in delays:
+            shift = int(round(d * fs))
+            sig = np.roll(base, shift)
+            voltage = np.clip(1.65 + 1.65 * sig, 0, 3.3)
+            signals.append(voltage)
+        return np.array(signals)
+
+    fs = 1000
+    sigs = generate_signals(fs=fs)
+    samples = sigs.shape[1]
+
+    ser = serial.Serial(port, baudrate=baud)
+    print(f"Sending data on {port} at {baud} baud")
     sys.stdout.flush()
 
     try:
         while True:
-            # Generate four random voltage readings between 0 and 3.3V
-            readings = [random.uniform(0, 3.3) for _ in range(4)]
-            for value in readings:
-                line = f"{value:.2f}\r\n".encode()
-                os.write(master, line)
-                time.sleep(0.01)
+            for i in range(samples):
+                for ch in range(sigs.shape[0]):
+                    line = f"{sigs[ch, i]:.2f}\r\n".encode()
+                    ser.write(line)
+                    # distribute the sampling interval across channels
+                    time.sleep(1 / (sigs.shape[0] * fs))
     except KeyboardInterrupt:
         pass
+    finally:
+        ser.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enhance the MCU simulator so that it uses `pyserial` to transmit
  predefined sine wave signals with delays between channels
- update README with new instructions for using COM11

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844271ae90883279866050f7376de47