### PR TITLE
Fix spectrogram signal casting

### DIFF
--- a/python_codes/compute_spectogram.py
+++ b/python_codes/compute_spectogram.py
@@ -9,6 +9,14 @@ def spectrogram(s1, s2, s3, s4, fs, axes=None, show=True):
 
     """Plot spectrograms for the four microphone signals."""
 
+    # ``scipy.signal.spectrogram`` expects numpy arrays.  The signals
+    # captured from the serial port are lists of floats, so convert them to
+    # arrays here to avoid attribute errors when SciPy accesses ``shape``.
+    s1 = np.asarray(s1)
+    s2 = np.asarray(s2)
+    s3 = np.asarray(s3)
+    s4 = np.asarray(s4)
+
     f1, t1, Sxx1 = signal.spectrogram(s1, fs)
     f2, t2, Sxx2 = signal.spectrogram(s2, fs)
     f3, t3, Sxx3 = signal.spectrogram(s3, fs)


### PR DESCRIPTION
## Summary
- ensure signals are numpy arrays inside `spectrogram`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python3 - <<'EOF'
import numpy as np
from python_codes.compute_spectogram import spectrogram
s = np.sin(2*np.pi*1*np.linspace(0,1,500))
ret = spectrogram(s.tolist(), np.roll(s,10).tolist(), np.roll(s,20).tolist(), np.roll(s,30).tolist(), fs=500, axes=None, show=False)
print('done', len(ret))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68443dfcc6b48327806d16c8228c9cee